### PR TITLE
Hide "Add to Calendar" button if calendar link is broken

### DIFF
--- a/components/upcoming-event.tsx
+++ b/components/upcoming-event.tsx
@@ -109,7 +109,8 @@ const UpcomingEvent = ({ event }: { event: PHEvent }) => {
               className={`pt-5 w-max ${
                 event.calLink === undefined ||
                 event.loc === 'TBD' ||
-                past(event.start)
+                past(event.start) ||
+                typeof event.calLink !== 'string'
                   ? 'hidden'
                   : ''
               }`}


### PR DESCRIPTION
Closes #43 

This was caused by the Airtable formula that generates the calendar link assuming an end time existed, but I think the button should also not appear if the calendar link is broken.

Merging now, but open to suggestions for iteration if we want. For example, I haven't explored this but maybe it would be better to display a grayed-out button with a tooltip instead of hiding it altogether.