### PR TITLE
Consistent-ize `ogUrl`, move to utils

### DIFF
--- a/components/past-event.tsx
+++ b/components/past-event.tsx
@@ -4,6 +4,7 @@ import { Clock } from 'react-feather'
 
 import { footer } from '../lib/footerPonderings'
 import { formatDate, startTimeFormatString } from '../lib/formatDate'
+import { ogUrl } from '../lib/utils'
 import Footer from './footer'
 import FooterLinks from './footer-links'
 import ImageGrid from './image-grid'
@@ -13,17 +14,6 @@ import Subhead from './subhead'
 import VercelBanner from './vercel-banner'
 
 const PastEvent = ({ event }: { event: PHEvent }) => {
-  const ogUrl = `https://og.purduehackers.com/${event.name.replace(
-    new RegExp(' ', 'g'),
-    '%20'
-  )}.png?theme=light&md=1&fontSize=${
-    event.name.length < 30 ? '250' : '200'
-  }px&caption=${
-    event.start !== 'TBD'
-      ? formatDate(new Date(event.start), 'LLL%20d%20•')
-      : ''
-  }%20${event.loc.replace(new RegExp(' ', 'g'), '%20')}`
-
   const [pondering, setPondering] = useState('')
 
   useEffect(() => {
@@ -43,7 +33,7 @@ const PastEvent = ({ event }: { event: PHEvent }) => {
             property="og:title"
             content={`${event.name} — Purdue Hackers`}
           />
-          <meta property="og:image" content={ogUrl} />
+          <meta property="og:image" content={ogUrl(event)} />
           <meta
             property="og:description"
             content={`${event.name}: a past event from Purdue Hackers.`}

--- a/components/upcoming-event.tsx
+++ b/components/upcoming-event.tsx
@@ -5,6 +5,7 @@ import { Calendar, Clock, MapPin } from 'react-feather'
 import { footer } from '../lib/footerPonderings'
 import { formatDate, startTimeFormatString } from '../lib/formatDate'
 import { past } from '../lib/past'
+import { ogUrl } from '../lib/utils'
 import DescriptionBox from './desc-box'
 import Footer from './footer'
 import FooterLinks from './footer-links'
@@ -20,17 +21,6 @@ const UpcomingEvent = ({ event }: { event: PHEvent }) => {
     setPondering(footer[Math.floor(Math.random() * footer.length)])
   }, [])
 
-  const ogUrl = `https://og.purduehackers.com/${event.name.replace(
-    new RegExp(' ', 'g'),
-    '%20'
-  )}.png?theme=${
-    event.name.includes('Hack Night') ? 'dark' : 'light'
-  }&md=1&fontSize=${event.name.length < 30 ? '250' : '200'}px&caption=${
-    event.start !== 'TBD'
-      ? formatDate(new Date(event.start), 'LLL%20d%20•')
-      : ''
-  }%20${event.loc.replace(new RegExp(' ', 'g'), '%20')}`
-
   const title = `${event.name} — Purdue Hackers`
 
   return (
@@ -44,7 +34,7 @@ const UpcomingEvent = ({ event }: { event: PHEvent }) => {
             property="og:title"
             content={`${event.name} — Purdue Hackers`}
           />
-          <meta property="og:image" content={ogUrl} />
+          <meta property="og:image" content={ogUrl(event)} />
           <meta
             property="og:description"
             content={

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,13 @@
+import { formatDate } from './formatDate'
+
+export const ogUrl = (event: PHEvent) =>
+  `https://og.purduehackers.com/${event.name.replace(
+    new RegExp(' ', 'g'),
+    '%20'
+  )}.png?theme=${
+    event.name.includes('Hack Night') ? 'dark' : 'light'
+  }&md=1&fontSize=${event.name.length < 30 ? '250' : '200'}px&caption=${
+    event.start !== 'TBD'
+      ? formatDate(new Date(event.start), 'LLL%20d%20•')
+      : ''
+  }%20${event.loc.replace(new RegExp(' ', 'g'), '%20')}`


### PR DESCRIPTION
The `ogUrl` was different for past events vs. future events, which shouldn't be the case. This PR moves the "correct" one into a new `utils` file and uses that in both past and future events.