### PR TITLE
Move Mailgun Domain

### DIFF
--- a/pages/api/addToMailingList.ts
+++ b/pages/api/addToMailingList.ts
@@ -22,7 +22,7 @@ export default (req: NextApiRequest, res: NextApiResponse) =>
     const mailgun = Mailgun
     const mg = mailgun({
       apiKey: `${process.env.MAILGUN_API_KEY}`,
-      domain: 'purduehackers.com',
+      domain: 'mg.purduehackers.com',
     })
 
     verifyUUID(email as string, uuid as string).then((valid) => {
@@ -40,14 +40,14 @@ export default (req: NextApiRequest, res: NextApiResponse) =>
             if (items.length === 0) {
               await mg
                 .post('/lists', {
-                  address: `${list}@purduehackers.com`,
+                  address: `${list}@mg.purduehackers.com`,
                   description: list,
                 })
                 .catch((_err) => {})
             }
             const item: MailingListData = items[0]
 
-            mg.lists(`${list}@purduehackers.com`)
+            mg.lists(`${list}@mg.purduehackers.com`)
               .members()
               .create({
                 address: email as string,

--- a/pages/api/sendReminder.ts
+++ b/pages/api/sendReminder.ts
@@ -18,7 +18,7 @@ const client = createClient({
 const mailgun = Mailgun
 const mg = mailgun({
   apiKey: `${process.env.MAILGUN_API_KEY}`,
-  domain: 'purduehackers.com',
+  domain: 'mg.purduehackers.com',
 })
 
 // eslint-disable-next-line import/no-anonymous-default-export
@@ -111,8 +111,8 @@ const sendEmail = async (
   console.log('parsed end', parsedEnd)
 
   const firstData = {
-    from: 'Purdue Hackers <events@purduehackers.com>',
-    to: `${slug}@purduehackers.com`,
+    from: 'Purdue Hackers <events@mg.purduehackers.com>',
+    to: `${slug}@mg.purduehackers.com`,
     subject: `Reminder: ${name} is happening tomorrow!`,
     template: 'event-reminder',
     'h:X-Mailgun-Variables': JSON.stringify({
@@ -124,8 +124,8 @@ const sendEmail = async (
   }
 
   const secondData = {
-    from: 'Purdue Hackers <events@purduehackers.com>',
-    to: `${slug}@purduehackers.com`,
+    from: 'Purdue Hackers <events@mg.purduehackers.com>',
+    to: `${slug}@mg.purduehackers.com`,
     subject: `[REMINDER] ${name} is happening today!`,
     template: 'second-event-reminder',
     'h:X-Mailgun-Variables': JSON.stringify({

--- a/pages/api/verifyEmail.ts
+++ b/pages/api/verifyEmail.ts
@@ -15,7 +15,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   const uuid = await generateUUID(email)
 
   const data = {
-    from: 'Purdue Hackers <events@purduehackers.com>',
+    from: 'Purdue Hackers <events@mg.purduehackers.com>',
     to: `${email}`,
     subject: `Purdue Hackers: Please verify your email`,
     template: 'verify-your-email',


### PR DESCRIPTION
I killed a few Mailgun-related addresses that have absolutely fucked our deliverability and blocked us from adding email forwarding. I've set up Mailgun to only handle delivering email and thats on mg.purduehackers.com.

Will fast follow this with a migration to Resend.